### PR TITLE
feat: better error reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER olizilla <oli@protocol.ai>
 
 WORKDIR /tmp
 
-ENV CLUSTER_VERSION v0.12.1
+ENV CLUSTER_VERSION v0.13.0
 ENV CLUSTER_TAR ipfs-cluster-ctl_${CLUSTER_VERSION}_linux-amd64.tar.gz
 
 RUN set -x \

--- a/README.md
+++ b/README.md
@@ -165,13 +165,20 @@ To rebuild the image
 
 ```bash
 docker build -t olizilla/ipfs-dns-deploy --build-arg GIT_COMMIT=$(git rev-parse HEAD) .
+...
+Successfully tagged olizilla/ipfs-dns-deploy:latest
 ```
 
 To push a new image to docker hub, login to docker, then
 
 ```bash
-docker tag olizilla/ipfs-dns-deploy olizilla/ipfs-dns-deploy:1.0
-docker push olizilla/ipfs-dns-deploy
+docker tag olizilla/ipfs-dns-deploy:latest olizilla/ipfs-dns-deploy:1.0
+
+# push the new tag
+docker push olizilla/ipfs-dns-deploy:1.0
+
+# update latest
+docker push olizilla/ipfs-dns-deploy:latest
 ```
 
 


### PR DESCRIPTION
- echo errors if either updating the gh status or pinning to cluster fails
- update to ipfs-cluster-ctl v0.13
- tweak docs

with this change failure to pin to cluster will show the command and error message
```
ipfs-cluster-ctl --host /dnsaddr/cluster.ipfs.io --basic-auth *** add --quieter --local --cid-version 1 --name 'test' --recursive .
An error occurred:
  Code: 401
  Message: Unauthorized
Failed to pin to cluster
```

failure to update github status will show the status code and request params used
```
curl: (22) The requested URL returned error: 401 Unauthorized
https://api.github.com/repos/ipfs-shipyard/ipfs-dns-deploy/statuses/8b93d943439f97ef9251bcea9bf292874ad1b04d {"state":"pending","target_url":"https://ipfs.io/","description":"Pinnning to IPFS cluster","context":"IPFS"}
Failed to update github status
```

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>