### PR TITLE
Add --wait arg to pin command

### DIFF
--- a/scripts/pin-to-cluster.sh
+++ b/scripts/pin-to-cluster.sh
@@ -54,6 +54,7 @@ root_cid=$(ipfs-cluster-ctl \
     --basic-auth "$CLUSTER_USER:$CLUSTER_PASSWORD" \
     add --quieter \
     --local \
+    --wait \
     --cid-version 1 \
     --name "$PIN_NAME" \
     --recursive "$INPUT_DIR" ) || {


### PR DESCRIPTION
This is trying to solve an issue where a process (CI worker) is spun up to build & pin a website. If the pin command returns immediately, the worker will shut down potentially before the CID is fully pinned.