### PR TITLE
feat: add EXTRA_IPFS_CLUSTER_ARGS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can get creative with the dns updating. In this example, changes to the `mas
 
 ## Requirements
 
-The following environment variables should be set
+The following environment variables must be set
 
 ```sh
 CLUSTER_USER="<beep>"
@@ -121,10 +121,21 @@ that can be shared across all repos in an github org.
 The script assumes it will have access to the circleci variables
 
 ```sh
+# Provided by circleci. Example values shown, yours will be different.
 CIRCLE_PROJECT_USERNAME="ipfs-shipyard"
 CIRCLE_PROJECT_REPONAME="peer-pad"
 CIRCLE_SHA1="f818cb08e0e79fcc203f4d52a1a1dd7c3c832a64"
 CIRCLE_BUILD_NUMBER="1870"
+```
+
+Optionally you can provide any of the following env vars:
+
+```sh
+# set the cluster host to pin to.
+CLUSTER_HOST="/dns/a-cluster-of-ones-own"
+
+# pass extra flags to ipfs-cluster-ctl
+EXTRA_IPFS_CLUSTER_ARGS="--hidden"
 ```
 
 ## Setting up a new org
@@ -145,6 +156,7 @@ docker run \
   -e CIRCLE_PROJECT_USERNAME="ipfs-shipyard" \
   -e CIRCLE_PROJECT_REPONAME="peer-pad" \
   -e CIRCLE_SHA1="f818cb08e0e79fcc203f4d52a1a1dd7c3c832a64" \
+  -e EXTRA_IPFS_CLUSTER_ARGS="--hidden" \
   -v build:/tmp/build \
   olizilla/ipfs-dns-deploy \
   pin-to-cluster.sh "dev.peerpad.net" ./build

--- a/scripts/pin-to-cluster.sh
+++ b/scripts/pin-to-cluster.sh
@@ -37,7 +37,7 @@ update_github_status () {
   # and it will print a useful error message with the status code. Combined with set -x this means
   # we stop the script and log an error.
   # We capture the output in $result here so that in the happy path it will not print anything; thhe only
-  # output we want on success is the CID from ipfs-cluster-ctl
+  # output we want on success is the CID from ipfs-cluster-ctl
   result=$(curl --fail --silent --show-error -X POST -H "Authorization: token $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" "$STATUS_API_URL") || {
     # If it fails show the url and params
     echo "$STATUS_API_URL $params" 1>&2
@@ -56,9 +56,11 @@ root_cid=$(ipfs-cluster-ctl \
     --local \
     --cid-version 1 \
     --name "$PIN_NAME" \
-    --recursive "$INPUT_DIR" ) || {
+    --recursive \
+    $EXTRA_IPFS_CLUSTER_ARGS \
+    "$INPUT_DIR" ) || {
   # If it fails, show the ipfs-cluster-ctl command and the error message
-  echo "ipfs-cluster-ctl --host $HOST --basic-auth *** add --quieter --local --cid-version 1 --name '$PIN_NAME' --recursive $INPUT_DIR" 1>&2
+  echo "ipfs-cluster-ctl --host $HOST --basic-auth *** add --quieter --local --cid-version 1 --name '$PIN_NAME' --recursive $EXTRA_IPFS_CLUSTER_ARGS $INPUT_DIR" 1>&2
   echo "$root_cid" 1>&2
   echo "Failed to pin to cluster" 1>&2
   false


### PR DESCRIPTION
*experts only*: allow the caller to pass extra flags to the `ipfs-cluster-ctl` command e.g. `--hidden`

This is prefeable to just passing any extra args from pin-to-cluster.sh to ipfs-cluster-ctl as it is explicit and does not preclude us from adding extra input args to pin-to-cluster.sh in the future.

fixes: #16
superceeds: https://github.com/ipfs-shipyard/ipfs-dns-deploy/pull/17

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>