### PR TITLE
feat: wait for cluster to pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER olizilla <oli@protocol.ai>
 
 WORKDIR /tmp
 
-ENV CLUSTER_VERSION v0.13.0
+ENV CLUSTER_VERSION v0.13.2
 ENV CLUSTER_TAR ipfs-cluster-ctl_${CLUSTER_VERSION}_linux-amd64.tar.gz
 
 RUN set -x \

--- a/scripts/pin-to-cluster.sh
+++ b/scripts/pin-to-cluster.sh
@@ -54,13 +54,14 @@ root_cid=$(ipfs-cluster-ctl \
     --basic-auth "$CLUSTER_USER:$CLUSTER_PASSWORD" \
     add --quieter \
     --local \
+    --wait \
     --cid-version 1 \
     --name "$PIN_NAME" \
     --recursive \
     $EXTRA_IPFS_CLUSTER_ARGS \
     "$INPUT_DIR" ) || {
   # If it fails, show the ipfs-cluster-ctl command and the error message
-  echo "ipfs-cluster-ctl --host $HOST --basic-auth *** add --quieter --local --cid-version 1 --name '$PIN_NAME' --recursive $EXTRA_IPFS_CLUSTER_ARGS $INPUT_DIR" 1>&2
+  echo "ipfs-cluster-ctl --host $HOST --basic-auth *** add --quieter --local --wait --cid-version 1 --name '$PIN_NAME' --recursive $EXTRA_IPFS_CLUSTER_ARGS $INPUT_DIR" 1>&2
   echo "$root_cid" 1>&2
   echo "Failed to pin to cluster" 1>&2
   false


### PR DESCRIPTION
- Update to ipfs-cluster-ctl@0.13.2
- Use the `--wait` to have the cli only return once cluster has finished pinning

see: https://github.com/ipfs/ipfs-cluster/pull/1301
see: https://github.com/protocol/bifrost-infra/issues/1116

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>