### PR TITLE
fix: build latest dnslink-dnsimple

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,30 @@
-FROM circleci/node:12.13
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20-bullseye AS builder
 MAINTAINER olizilla <oli@protocol.ai>
+
+ARG TARGETPLATFORM TARGETOS TARGETARCH
+ENV GOPATH /go
 
 WORKDIR /tmp
 
-ENV CLUSTER_VERSION v1.0.6
-ENV CLUSTER_TAR ipfs-cluster-ctl_${CLUSTER_VERSION}_linux-amd64.tar.gz
+ENV DNSLINK_DNSIMPLE_VERSION v0.1.0
+ENV CLUSTER_VERSION v1.0.7
 
-# Fix certificates
-RUN sudo apt-get update && sudo apt-get install -y ca-certificates libgnutls30 wget && sudo update-ca-certificates
-
-RUN set -x \
-  && wget "https://dist.ipfs.io/ipfs-cluster-ctl/$CLUSTER_VERSION/$CLUSTER_TAR" \
-  && tar -xzf "$CLUSTER_TAR" --strip-components=1 ipfs-cluster-ctl/ipfs-cluster-ctl \
-  && sudo mv ipfs-cluster-ctl /usr/local/bin
-
-RUN set -x \
-  && wget --quiet https://ipfs.io/ipfs/QmNgtrMpFRFFr7Gdw9HjoK2H43aVnQ1Ygu87kLP5CZRxB5/ -O dnslink-dnsimple \
-  && chmod +x dnslink-dnsimple \
-  && sudo mv dnslink-dnsimple /usr/local/bin
+RUN go install github.com/ipfs-cluster/ipfs-cluster/cmd/ipfs-cluster-ctl@${CLUSTER_VERSION}
+RUN go install github.com/ipfs/dnslink-dnsimple@${DNSLINK_DNSIMPLE_VERSION}
 
 COPY scripts/pin-to-cluster.sh /usr/local/bin
-RUN sudo chown circleci:circleci /usr/local/bin/pin-to-cluster.sh
-RUN sudo chmod go+rx /usr/local/bin/pin-to-cluster.sh
+RUN chmod go+rx /usr/local/bin/pin-to-cluster.sh
+
+#------------------------------------------------------
+FROM alpine:3.18
+
+ENV GOPATH /go
+
+RUN apk add --no-cache gcompat bash ca-certificates
+
+COPY --from=builder $GOPATH/bin/dnslink-dnsimple /usr/local/bin/dnslink-dnsimple
+COPY --from=builder $GOPATH/bin/ipfs-cluster-ctl /usr/local/bin/ipfs-cluster-ctl
+COPY --from=builder /usr/local/bin/pin-to-cluster.sh /usr/local/bin/pin-to-cluster.sh
 
 ARG GIT_COMMIT=unspecified
 LABEL git_commit=$GIT_COMMIT


### PR DESCRIPTION
This PR updates Dockerfile to build latest version of `dnslink-dnsimple@v0.1.0` which no longer produce duplicate TXT records.

Context: https://github.com/protocol/bifrost-infra/issues/2814 

cc @olizilla @ns4plabs @cewood @hacdias
